### PR TITLE
Docker layer caching

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -31,10 +31,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to Docker registry
-        run: docker login
-          ${{ secrets.CONTAINER_REGISTRY_SERVER }}
-          --username=${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-          --password=${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.CONTAINER_REGISTRY_SERVER }}
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Infuse with secrets
         run: |
@@ -54,6 +55,13 @@ jobs:
 
       - name: Tag name
         run: echo ${{ steps.tag.outputs.docker_tag }}
+
+      # In this step, this action saves a list of existing images,
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
 
       - name: Build Docker image
         run: docker build -t


### PR DESCRIPTION
Introducing docker layer reduced the CI run time to < 3 mins, down from the original 8--10 minute runs.

_However_, the initial run (no cache available) will take ~1min longer while the cache is prepared and output. However, with consecutive builds being faster this still represents an overall time saving.

![image](https://user-images.githubusercontent.com/32269169/119217761-45188500-bad4-11eb-86a4-ff30e03196b4.png)