### PR TITLE
Add Docker caching support to GitHub Actions

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -31,10 +31,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to Docker registry
-        run: docker login
-          ${{ secrets.CONTAINER_REGISTRY_SERVER }}
-          --username=${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-          --password=${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.CONTAINER_REGISTRY_SERVER }}
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Infuse with secrets
         run: |
@@ -54,6 +55,13 @@ jobs:
 
       - name: Tag name
         run: echo ${{ steps.tag.outputs.docker_tag }}
+
+      # In this step, this action saves a list of existing images,
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
 
       - name: Build Docker image
         run: docker build -t


### PR DESCRIPTION
This Pull Request adds docker cache support to GitHub Actions.

The changes here will make the initial image build a touch slower, as the cache has to be stored. But subsequent builds should be much faster.